### PR TITLE
Switch tests to pytest testing framework

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,26 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        python-version: [ '3.8' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: 'Set up Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@v3
+        with:
+          python-version: '${{ matrix.python-version }}'
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - run: sudo apt-get update
+      - uses: actions/checkout@v3
+      #- run: sudo apt-get update
+      - run: python --version
+      - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
-      - run: python tests/fetch_config.py https://devxnat.barcelonabeta.org --xnat_user $XNAT_USER --xnat_password $XNAT_PASSWORD
+      - name: Run tests
+        run: python tests/fetch_config.py https://devxnat.barcelonabeta.org --xnat_user $XNAT_USER --xnat_password $XNAT_PASSWORD
         env:
           XNAT_USER: ${{ secrets.XNAT_USER }}
           XNAT_PASSWORD: ${{ secrets.XNAT_PASSWORD }}
@@ -35,6 +45,7 @@ jobs:
         env:
           CI_TEST: 0
           PYTHONPATH: $PYTHONPATH:$(pwd)
-      - run: coveralls --service=github
+      - name: Check code coverage
+        run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![downloads](https://img.shields.io/pypi/dm/nisnap.svg)](https://pypi.org/project/nisnap/)
 [![python versions](https://img.shields.io/pypi/pyversions/nisnap.svg)](https://pypi.org/project/nisnap/)
 [![pypi version](https://img.shields.io/pypi/v/nisnap.svg)](https://pypi.org/project/nisnap/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4075418.svg)](https://doi.org/10.5281/zenodo.4075418)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5779222.svg)](https://doi.org/10.5281/zenodo.5779222)
 
 
 Create snapshots of segmentation maps produced by neuroimaging software.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+pythonpath = .
+python_files = tests.py
+addopts =
+  -v
+  --tb=short
+  --cov=nisnap
+  --cov=tests
+  --cov-report=term-missing:skip-covered
+  --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-coverage>=4.5
-nose>=1.3
 matplotlib>=2.2
 pyxnat>=1.3
 tqdm>=4.31
@@ -9,4 +7,8 @@ urllib3>=1.24
 ipython>=7.3
 Pillow>=7.0
 nilearn>=0.8
+# testing
+pytest>=7.1
+pytest-cov>=4.0
+coverage>=4.5
 coveralls


### PR DESCRIPTION
Change proposal for migrating pyxnat's testing framework from ([nose](https://nose.readthedocs.io/)) to [pytest](https://pytest.org/) framework.

Nose development has been [discontinued](https://nose.readthedocs.io/en/latest/#note-to-users) and is not actively maintained anymore, which could lead to future problems for this project and its dependencies. On the other hand, pytest is currently an actively maintained and widely used framework for functional testing. Supports running legacy unittest tests (and nose), so switching to pytest is an -almost- straight-forward choice.